### PR TITLE
Wrong type infered in jsrocq

### DIFF
--- a/src/writing_proofs/tutorial_intro_patterns.v
+++ b/src/writing_proofs/tutorial_intro_patterns.v
@@ -266,7 +266,7 @@ Abort.
 (** A particularly useful case is to introduce existentially quantified hypotheses.
 *)
 
-Goal forall P Q (f : forall x y, P x y -> Q x y),
+Goal forall (P Q : nat -> nat -> Prop) (f : forall x y, P x y -> Q x y),
      (exists (x y: nat), P x y) -> (exists (x y : nat), Q x y).
 Proof.
   intros P Q f (x & y & Pxy).


### PR DESCRIPTION
On the [website](https://rocq-prover.github.io/platform-docs/writing_proofs/tutorial_intro_patterns.html), the `Goal` command fails because the infered type of `P` and `Q` is `nat -> nat -> Type`, instead of `nat -> nat -> Prop`.